### PR TITLE
feat: expose metrics at /metrics on api port

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -121,7 +121,8 @@ func Start(cfg *config.Config) error {
 	// Set metrics router
 	metrics.Expose(metricsRouter)
 	// Use metrics middleware without exposing path in main app router
-	metrics.UseWithoutExposingEndpoint(router)
+	metrics.SetMetricPath("/metrics")
+	metrics.Use(router)
 
 	// Custom metrics
 	failureMetric := &ginmetrics.Metric{


### PR DESCRIPTION
This prevents us from needing to do terrible things with CORS.

This works on both paths, the API port on `/metrics` and the metrics port at `/` so it won't break any existing monitors, etc.