### PR TITLE
fix: use /metrics on the main router

### DIFF
--- a/internal/api/static/index.html
+++ b/internal/api/static/index.html
@@ -57,7 +57,7 @@
         <div
           id="metrics-container"
           class="flex items-center flex-wrap font-mono gap-4 whitespace-pre mb-4"
-          hx-get="javascript:window.location.protocol + '//' + window.location.hostname + ':8081/'"
+          hx-get="/metrics"
           hx-trigger="load, every 1s"
           hx-swap="innerHTML"
         >


### PR DESCRIPTION
Avoid the CORS mess.

![Screenshot 2024-10-18 at 3 34 58 PM](https://github.com/user-attachments/assets/deefd527-355f-4ebb-8170-bde949f88d6c)
