### PR TITLE
ci: pin to sha for conventional commits workflow

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -13,5 +13,5 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: webiny/action-conventional-commits@v1.4.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
+      - uses: webiny/action-conventional-commits@7f91b1595ca1951cdb671ddc9f07a49081ec5b69 # v1.4.2 https://github.com/webiny/action-conventional-commits/releases/tag/v1.4.2


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pin `actions/checkout` and `webiny/action-conventional-commits` to specific commit SHAs in the `conventional-commits` workflow to improve reproducibility and supply-chain security.

<sup>Written for commit b00b6c04a96f45fceb1c1ed7cb6ee7703493e8f7. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/tx-submit-api/pull/445?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

