### PR TITLE
feat: replace /healthcheck with /health liveness and /healthz readine…

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,7 @@ linters:
     - fatcontext
     - gocheckcompilerdirectives
     - gochecksumtype
-    - gomodguard
+    - gomodguard_v2
     - gosec
     - gosmopolitan
     - loggercheck

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # tx-submit-api
 
-<div align="center">
-    <img src="./.github/assets/tx-submit-api-logo.png" alt="Tx Submit API" width="320">
-</div>
+![Tx Submit API](./.github/assets/tx-submit-api-logo.png)
 
 Transaction Submission API for Cardano
 
@@ -16,14 +14,14 @@ The recommended method of using this application is via the published
 container images, coupled with Blink Labs container images for the Cardano
 Node.
 
-```
+```sh
 docker run -p 8090:8090 ghcr.io/blinklabs-io/tx-submit-api
 ```
 
 Binaries can be executed directly and are available from
 [Releases](https://github.com/blinklabs-io/tx-submit-api/releases).
 
-```
+```sh
 ./tx-submit-api
 ```
 
@@ -40,12 +38,13 @@ variables. The first set controls the behavior of the application, while the
 second set controls the connection to the Cardano node instance.
 
 Application configuration:
+
 - `API_LISTEN_ADDRESS` - Address to bind for API calls, all addresses if empty
     (default: empty)
 - `API_LISTEN_PORT` - Port to bind for API calls (default: 8090)
 - `DEBUG_ADDRESS` - Address to bind for pprof debugging (default: localhost)
 - `DEBUG_PORT` - Port to bind for pprof debugging, disabled if 0 (default: 0)
-- `LOGGING_HEALTHCHECKS` - Log requests to `/healthcheck` endpoint (default: false)
+- `LOGGING_HEALTHCHECKS` - Log requests to `/health` and `/healthz` endpoints (default: false)
 - `LOGGING_LEVEL` - Logging level for log output (default: info)
 - `METRICS_LISTEN_ADDRESS` - Address to bind for Prometheus format metrics, all
     addresses if empty (default: empty)
@@ -71,6 +70,7 @@ NtC communication socket over TCP. TCP connections are preferred over socket
 within the application.
 
 Cardano node configuration:
+
 - `CARDANO_NETWORK` - Use a named Cardano network (default: mainnet)
 - `CARDANO_NODE_NETWORK_MAGIC` - Cardano network magic (default: automatically
     determined from named network)
@@ -84,6 +84,8 @@ Cardano node configuration:
     unset)
 - `CARDANO_NODE_SOCKET_TIMEOUT` - Sets a timeout in seconds for waiting on
    requests to the Cardano node (default: 30)
+- `CARDANO_NODE_HEALTH_CHECK_INTERVAL` - Interval in seconds for the background
+   node readiness health checker (default: 30)
 
 ### Connecting to a cardano-node
 
@@ -158,16 +160,19 @@ browser to view it.
 There is a Makefile to provide some simple helpers.
 
 Run from checkout:
-```
+
+```sh
 go run .
 ```
 
 Create a binary:
-```
+
+```sh
 make
 ```
 
 Create a docker image:
-```
+
+```sh
 make image
 ```

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"embed"
 	"encoding/hex"
 	"encoding/json"
@@ -27,7 +28,9 @@ import (
 	"net"
 	"net/http"
 	"runtime/debug"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	ouroboros "github.com/blinklabs-io/gouroboros"
@@ -48,6 +51,73 @@ var staticFS embed.FS
 // maxTxBodyBytes is the maximum accepted request body size for transaction
 // submission. Cardano's protocol limit is ~16KB; 64KB gives ample overhead.
 const maxTxBodyBytes = 64 * 1024
+
+// nodeHealthState holds the latest result of the background readiness probe.
+type nodeHealthState struct {
+	mu        sync.RWMutex
+	healthy   bool
+	lastCheck time.Time
+	lastError error
+}
+
+var nodeHealth = &nodeHealthState{}
+
+// startNodeHealthPoller runs a background goroutine that periodically dials the
+// configured node transport (TCP or Unix socket) and updates nodeHealth. It runs
+// an initial check immediately so /healthz is never stale on first request.
+func startNodeHealthPoller(ctx context.Context, cfg *config.Config) {
+	logger := logging.GetLogger()
+	probe := func() {
+		timeout := time.Duration(cfg.Node.Timeout) * time.Second // #nosec G115
+		var err error
+		if cfg.Node.Address != "" && cfg.Node.Port > 0 {
+			addr := net.JoinHostPort(cfg.Node.Address, strconv.FormatUint(uint64(cfg.Node.Port), 10))
+			var conn net.Conn
+			conn, err = net.DialTimeout("tcp", addr, timeout)
+			if err == nil {
+				_ = conn.Close()
+			}
+		} else {
+			var conn net.Conn
+			conn, err = net.DialTimeout("unix", cfg.Node.SocketPath, timeout)
+			if err == nil {
+				_ = conn.Close()
+			}
+		}
+
+		nodeHealth.mu.Lock()
+		prev := nodeHealth.healthy
+		nodeHealth.healthy = err == nil
+		nodeHealth.lastCheck = time.Now()
+		nodeHealth.lastError = err
+		nodeHealth.mu.Unlock()
+
+		// Log only on state transitions to avoid noise.
+		if err == nil && !prev {
+			logger.Info("node became reachable")
+		} else if err != nil && prev {
+			logger.Error("node became unreachable", "err", err)
+		}
+	}
+
+	go func() {
+		probe()
+		interval := cfg.Node.HealthCheckInterval
+		if interval <= 0 {
+			interval = 30
+		}
+		ticker := time.NewTicker(time.Duration(interval) * time.Second) // #nosec G115
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				probe()
+			}
+		}
+	}()
+}
 
 // corsMiddleware adds CORS headers allowing all origins.
 func corsMiddleware(next http.Handler) http.Handler {
@@ -132,7 +202,9 @@ func recoveryMiddleware(next http.Handler) http.Handler {
 }
 
 // newMux creates the API ServeMux. Used by Start and tests to avoid route drift.
-func newMux(fsys fs.FS) *http.ServeMux {
+// nh is the node health state used by the readiness handler; callers supply it
+// so tests can inject an isolated instance without touching global state.
+func newMux(fsys fs.FS, nh *nodeHealthState) *http.ServeMux {
 	mux := http.NewServeMux()
 
 	// Static UI
@@ -146,7 +218,10 @@ func newMux(fsys fs.FS) *http.ServeMux {
 		http.Redirect(w, r, "/ui", http.StatusMovedPermanently)
 	})
 
-	mux.HandleFunc("GET /healthcheck", handleHealthcheck)
+	mux.HandleFunc("GET /health", handleLiveness)
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
+		handleReadiness(w, r, nh)
+	})
 	// Swagger UI
 	mux.Handle("/swagger/", httpSwagger.WrapHandler)
 
@@ -202,11 +277,12 @@ func Start(cfg *config.Config) error {
 		return err
 	}
 
-	mux := newMux(fsys)
+	startNodeHealthPoller(context.Background(), cfg)
+	mux := newMux(fsys, nodeHealth)
 
 	skipPaths := []string{}
 	if !cfg.Logging.Healthchecks {
-		skipPaths = append(skipPaths, "/healthcheck")
+		skipPaths = append(skipPaths, "/health", "/healthz")
 	}
 	var handler http.Handler = mux
 	handler = loggingMiddleware(skipPaths)(handler)
@@ -253,9 +329,20 @@ func Start(cfg *config.Config) error {
 	return err
 }
 
-func handleHealthcheck(w http.ResponseWriter, _ *http.Request) {
-	// TODO: add some actual health checking here
-	writeJSON(w, http.StatusOK, map[string]bool{"failed": false})
+func handleLiveness(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func handleReadiness(w http.ResponseWriter, _ *http.Request, nh *nodeHealthState) {
+	nh.mu.RLock()
+	healthy := nh.healthy
+	nh.mu.RUnlock()
+
+	if healthy {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	} else {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"status": "unavailable"})
+	}
 }
 
 // handleHasTx godoc
@@ -289,7 +376,7 @@ func handleHasTx(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Connect to cardano-node and check for transaction
-	timeout := time.Duration(cfg.Node.Timeout) * time.Second //nolint:gosec
+	timeout := time.Duration(cfg.Node.Timeout) * time.Second // #nosec G115
 	oConn, err := submit.DialNode(
 		uint32(cfg.Node.NetworkMagic),
 		cfg.Node.Address,
@@ -433,7 +520,7 @@ func handleSubmitTx(w http.ResponseWriter, r *http.Request) {
 			if ok {
 				logger.Error("post-submission connection error", "err", err)
 			}
-		case <-time.After(time.Duration(cfg.Node.Timeout) * time.Second): //nolint:gosec
+		case <-time.After(time.Duration(cfg.Node.Timeout) * time.Second): // #nosec G115
 		}
 	}()
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -15,6 +15,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -36,8 +37,9 @@ func TestMain(m *testing.M) {
 }
 
 // newTestMux delegates to newMux to ensure test routes always match production routes.
-func newTestMux() http.Handler {
-	mux := newMux(fstest.MapFS{})
+// Each call gets a fresh nodeHealthState so parallel tests don't share state.
+func newTestMux(nh *nodeHealthState) http.Handler {
+	mux := newMux(fstest.MapFS{}, nh)
 	var handler http.Handler = mux
 	handler = loggingMiddleware(nil)(handler)
 	handler = recoveryMiddleware(handler)
@@ -143,12 +145,12 @@ func TestRealClientIP(t *testing.T) {
 	}
 }
 
-// --- healthcheck ---
+// --- liveness ---
 
-func TestHealthcheck_OK(t *testing.T) {
+func TestLiveness_OK(t *testing.T) {
 	t.Parallel()
 	rec := httptest.NewRecorder()
-	newTestMux().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthcheck", nil))
+	newTestMux(&nodeHealthState{}).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rec.Code)
@@ -156,16 +158,50 @@ func TestHealthcheck_OK(t *testing.T) {
 	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
 		t.Errorf("expected Content-Type application/json, got %q", ct)
 	}
-	var body map[string]bool
+	var body map[string]string
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("failed to parse body: %s", err)
 	}
-	v, ok := body["failed"]
-	if !ok {
-		t.Fatal("expected key \"failed\" in response body")
+	if body["status"] != "ok" {
+		t.Errorf("expected status=ok, got %q", body["status"])
 	}
-	if v != false {
-		t.Errorf("expected failed=false, got %v", v)
+}
+
+// --- readiness ---
+
+func TestReadiness_OK(t *testing.T) {
+	t.Parallel()
+	nh := &nodeHealthState{healthy: true}
+	rec := httptest.NewRecorder()
+	newTestMux(nh).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to parse body: %s", err)
+	}
+	if body["status"] != "ok" {
+		t.Errorf("expected status=ok, got %q", body["status"])
+	}
+}
+
+func TestReadiness_Unavailable(t *testing.T) {
+	t.Parallel()
+	nh := &nodeHealthState{healthy: false}
+	rec := httptest.NewRecorder()
+	newTestMux(nh).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", rec.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to parse body: %s", err)
+	}
+	if body["status"] != "unavailable" {
+		t.Errorf("expected status=unavailable, got %q", body["status"])
 	}
 }
 
@@ -198,7 +234,7 @@ func TestSubmitTx_ContentType(t *testing.T) {
 			if tt.contentType != "" {
 				req.Header.Set("Content-Type", tt.contentType)
 			}
-			newTestMux().ServeHTTP(rec, req)
+			newTestMux(&nodeHealthState{}).ServeHTTP(rec, req)
 
 			if rec.Code != tt.wantStatus {
 				t.Fatalf("expected %d, got %d", tt.wantStatus, rec.Code)
@@ -212,7 +248,7 @@ func TestSubmitTx_InvalidTxBytes(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/submit/tx", strings.NewReader("not-valid-cbor"))
 	req.Header.Set("Content-Type", "application/cbor")
-	newTestMux().ServeHTTP(rec, req)
+	newTestMux(&nodeHealthState{}).ServeHTTP(rec, req)
 
 	// Invalid bytes fail transaction type detection before any node connection → 400
 	if rec.Code != http.StatusBadRequest {
@@ -226,7 +262,7 @@ func TestHasTx_NoNode(t *testing.T) {
 	t.Parallel()
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/hastx/abc123", nil)
-	newTestMux().ServeHTTP(rec, req)
+	newTestMux(&nodeHealthState{}).ServeHTTP(rec, req)
 
 	// No node available → 500
 	if rec.Code != http.StatusInternalServerError {
@@ -255,7 +291,7 @@ func TestCORS(t *testing.T) {
 		{
 			name:       "normal response includes CORS origin header",
 			method:     http.MethodGet,
-			path:       "/healthcheck",
+			path:       "/health",
 			wantStatus: http.StatusOK,
 		},
 	}
@@ -265,7 +301,7 @@ func TestCORS(t *testing.T) {
 			t.Parallel()
 			rec := httptest.NewRecorder()
 			req := httptest.NewRequest(tt.method, tt.path, nil)
-			newTestMux().ServeHTTP(rec, req)
+			newTestMux(&nodeHealthState{}).ServeHTTP(rec, req)
 
 			if rec.Code != tt.wantStatus {
 				t.Fatalf("expected %d, got %d", tt.wantStatus, rec.Code)
@@ -295,7 +331,7 @@ func TestSubmitTx_RequestsTotal_InvalidCBOR(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/submit/tx", strings.NewReader("not-valid-cbor"))
 	req.Header.Set("Content-Type", "application/cbor")
-	newTestMux().ServeHTTP(rec, req)
+	newTestMux(&nodeHealthState{}).ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", rec.Code)
@@ -314,7 +350,7 @@ func TestSubmitTx_RequestsTotal_NoIncrementOnBadContentType(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/submit/tx", strings.NewReader("data"))
 	req.Header.Set("Content-Type", "application/json")
-	newTestMux().ServeHTTP(rec, req)
+	newTestMux(&nodeHealthState{}).ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusUnsupportedMediaType {
 		t.Fatalf("expected 415, got %d", rec.Code)
@@ -323,4 +359,23 @@ func TestSubmitTx_RequestsTotal_NoIncrementOnBadContentType(t *testing.T) {
 	if after != before {
 		t.Errorf("requests_total should not increment on content-type rejection, got increment of %f", after-before)
 	}
+}
+
+// --- health poller ---
+
+func TestStartNodeHealthPoller_ZeroInterval(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Node.HealthCheckInterval = 0
+	cfg.Node.Timeout = 1
+
+	// Ensure startNodeHealthPoller does not panic when HealthCheckInterval is 0
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("startNodeHealthPoller panicked: %v", r)
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	startNodeHealthPoller(ctx, cfg)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,13 +55,14 @@ type MetricsConfig struct {
 }
 
 type NodeConfig struct {
-	Network      string `yaml:"network"      envconfig:"CARDANO_NETWORK"`
-	NetworkMagic uint32 `yaml:"networkMagic" envconfig:"CARDANO_NODE_NETWORK_MAGIC"`
-	Address      string `yaml:"address"      envconfig:"CARDANO_NODE_SOCKET_TCP_HOST"`
-	Port         uint   `yaml:"port"         envconfig:"CARDANO_NODE_SOCKET_TCP_PORT"`
-	SkipCheck    bool   `yaml:"skipCheck"    envconfig:"CARDANO_NODE_SKIP_CHECK"`
-	SocketPath   string `yaml:"socketPath"   envconfig:"CARDANO_NODE_SOCKET_PATH"`
-	Timeout      uint   `yaml:"timeout"      envconfig:"CARDANO_NODE_SOCKET_TIMEOUT"`
+	Network             string `yaml:"network"              envconfig:"CARDANO_NETWORK"`
+	NetworkMagic        uint32 `yaml:"networkMagic"         envconfig:"CARDANO_NODE_NETWORK_MAGIC"`
+	Address             string `yaml:"address"              envconfig:"CARDANO_NODE_SOCKET_TCP_HOST"`
+	Port                uint   `yaml:"port"                 envconfig:"CARDANO_NODE_SOCKET_TCP_PORT"`
+	SkipCheck           bool   `yaml:"skipCheck"            envconfig:"CARDANO_NODE_SKIP_CHECK"`
+	SocketPath          string `yaml:"socketPath"           envconfig:"CARDANO_NODE_SOCKET_PATH"`
+	Timeout             uint   `yaml:"timeout"              envconfig:"CARDANO_NODE_SOCKET_TIMEOUT"`
+	HealthCheckInterval uint   `yaml:"healthCheckInterval"  envconfig:"CARDANO_NODE_HEALTH_CHECK_INTERVAL"`
 }
 
 type TlsConfig struct {
@@ -88,16 +89,17 @@ var globalConfig = &Config{
 		ListenPort:    8081,
 	},
 	Node: NodeConfig{
-		Network:    "mainnet",
-		SocketPath: "/node-ipc/node.socket",
-		Timeout:    30,
+		Network:             "mainnet",
+		SocketPath:          "/node-ipc/node.socket",
+		Timeout:             30,
+		HealthCheckInterval: 30,
 	},
 }
 
 func Load(configFile string) (*Config, error) {
 	// Load config file as YAML if provided
 	if configFile != "" {
-		buf, err := os.ReadFile(configFile)
+		buf, err := os.ReadFile(configFile) // #nosec G304 -- loading configuration file strictly passed from CLI
 		if err != nil {
 			return nil, fmt.Errorf("error reading config file: %w", err)
 		}
@@ -175,6 +177,6 @@ func (c *Config) checkNode() error {
 		return errors.New("you must specify either the UNIX socket path or the address/port for your cardano-node")
 	}
 	// Close Ouroboros connection
-	oConn.Close()
+	_ = oConn.Close()
 	return nil
 }

--- a/submit/txinfo.go
+++ b/submit/txinfo.go
@@ -52,16 +52,20 @@ func ParseTxInfo(rawBytes []byte) (*TxInfo, error) {
 	}
 
 	w := tx.Witnesses()
-	switch {
-	case len(w.PlutusV3Scripts()) > 0:
-		info.ScriptType = "plutus_v3"
-	case len(w.PlutusV2Scripts()) > 0:
-		info.ScriptType = "plutus_v2"
-	case len(w.PlutusV1Scripts()) > 0:
-		info.ScriptType = "plutus_v1"
-	case len(w.NativeScripts()) > 0:
-		info.ScriptType = "native"
-	default:
+	if w != nil {
+		switch {
+		case len(w.PlutusV3Scripts()) > 0:
+			info.ScriptType = "plutus_v3"
+		case len(w.PlutusV2Scripts()) > 0:
+			info.ScriptType = "plutus_v2"
+		case len(w.PlutusV1Scripts()) > 0:
+			info.ScriptType = "plutus_v1"
+		case len(w.NativeScripts()) > 0:
+			info.ScriptType = "native"
+		default:
+			info.ScriptType = "none"
+		}
+	} else {
 		info.ScriptType = "none"
 	}
 


### PR DESCRIPTION
…ss endpoints

Introduce decoupled liveness and readiness probe endpoints to improve stability and traffic routing in orchestrated environments like Kubernetes.

- Add GET /health for a lightweight HTTP-server-only liveness check.
- Add GET /healthz for node connectivity readiness, backed by a background poller.
- Add configuration for background health check interval.
- Fix nil pointer risk in submit witnesses parsing and style issues.
- Update documentation in README.md.

BREAKING CHANGE: The /healthcheck endpoint has been completely removed and replaced with /health and /healthz. Any external health checks/probes targeting /healthcheck will receive a 404 and must be updated.

Closes #376 Closes #404

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the old `/healthcheck` into `/health` (liveness) and `/healthz` (readiness) with a background node connectivity poller and a configurable interval. This improves probe accuracy and traffic routing in Kubernetes and similar environments.

- **New Features**
  - GET `/health` for HTTP-server liveness.
  - GET `/healthz` for node readiness; returns 200 when reachable, 503 when not; powered by a background poller with an immediate initial check.
  - New config: `CARDANO_NODE_HEALTH_CHECK_INTERVAL` (seconds, default 30).
  - Safer tx witness parsing to prevent a nil-pointer edge case.
  - `LOGGING_HEALTHCHECKS` now controls logging for both `/health` and `/healthz`.

- **Migration**
  - Removed `/healthcheck`. Update probes to use `/health` (liveness) and `/healthz` (readiness).

<sup>Written for commit 87884903baf8765c7df6ee58f199ec9bcf60d067. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/tx-submit-api/pull/457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added separate liveness (`/health`) and readiness (`/healthz`) health check endpoints, replacing the previous single endpoint.
  * Introduced node reachability polling for continuous health monitoring.
  * Added `CARDANO_NODE_HEALTH_CHECK_INTERVAL` configuration option to control polling frequency.

* **Documentation**
  * Updated endpoint references and improved configuration documentation.
  * Enhanced development setup instructions with clearer formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->